### PR TITLE
Add admin page with session creation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,8 +18,9 @@ var sessions = make(map[string]string) // sessionId -> roomName
 func main() {
 	// Main routes
 	http.HandleFunc("/", serveHomePage)
-	http.HandleFunc("/empregado", serveEmployeePage)
-	http.HandleFunc("/cliente/", serveClientPage)
+       http.HandleFunc("/empregado", serveEmployeePage)
+       http.HandleFunc("/admin", serveAdminPage)
+       http.HandleFunc("/cliente/", serveClientPage)
 	http.HandleFunc("/debug", serveDebugPage)
 	http.HandleFunc("/test", serveTestPage)
 	http.HandleFunc("/comprehensive-test", serveComprehensiveTestPage)
@@ -85,8 +86,13 @@ func serveHomePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveEmployeePage(w http.ResponseWriter, r *http.Request) {
-	tmpl := template.Must(template.ParseFiles("templates/empregado.html"))
-	tmpl.Execute(w, nil)
+        tmpl := template.Must(template.ParseFiles("templates/empregado.html"))
+        tmpl.Execute(w, nil)
+}
+
+func serveAdminPage(w http.ResponseWriter, r *http.Request) {
+        tmpl := template.Must(template.ParseFiles("templates/admin.html"))
+        tmpl.Execute(w, nil)
 }
 
 func serveClientPage(w http.ResponseWriter, r *http.Request) {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin - QRKit</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f5f5f5;
+            padding: 40px;
+            text-align: center;
+        }
+        .btn {
+            padding: 15px 25px;
+            font-size: 1em;
+            background: #007bff;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        .btn:hover {
+            background: #0056b3;
+        }
+        .qr {
+            margin-top: 20px;
+        }
+        .qr img {
+            max-width: 200px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Área Administrativa</h1>
+    <button id="createBtn" class="btn">Criar Sessão</button>
+    <div id="qr" class="qr" style="display:none;">
+        <h3>QR Code da Sessão</h3>
+        <img id="qrImg" src="" alt="QR Code">
+    </div>
+    <script>
+        document.getElementById('createBtn').addEventListener('click', async () => {
+            const resp = await fetch('/api/create-session', {method: 'POST'});
+            if (!resp.ok) {
+                alert('Erro ao criar sessão');
+                return;
+            }
+            const data = await resp.json();
+            document.getElementById('qrImg').src = '/api/qr/' + data.sessionId;
+            document.getElementById('qr').style.display = 'block';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal admin page to create sessions and show QR code
- serve new page from `/admin`

## Testing
- `go build ./cmd/server` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684490d08c64832884899263ba24591f