### PR TITLE
Fix build settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine
+FROM golang:1.22-alpine
 
 WORKDIR /app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alvarolopes/qrkit
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/livekit/protocol v1.39.0


### PR DESCRIPTION
## Summary
- fix Docker base image to a real version
- update go.mod to match new Go version

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3b410ac8328a71a62a8ca89e773