### PR TITLE
Add nixpacks config for Go 1.24

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[providers]
+go = { version = "1.24" }


### PR DESCRIPTION
## Summary
- configure Nixpacks to use Go 1.24

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9050630832888cd89fa953eee99