### PR TITLE
Fix Nixpacks config

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,8 @@
-[providers]
-go = { version = "1.24" }
+[phases.setup]
+nixPkgs = ["go_1_24"]
+
+[phases.build]
+cmds = ["go build -o out ./cmd/server"]
+
+[start]
+cmd = "./out"


### PR DESCRIPTION
## Summary
- fix `nixpacks.toml` syntax so Go 1.24 is installed correctly

## Testing
- `go build ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0ca78dc83289b618590d775c26c