### PR TITLE
Fix Nixpacks build to use Go 1.23

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["go_1_24"]
+nixPkgs = ["go_1_23"]
 
 [phases.build]
 cmds = ["go build -o out ./cmd/server"]


### PR DESCRIPTION
## Summary
- update `nixpacks.toml` to use `go_1_23`

## Testing
- `go build ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6844b6c7e7dc8328a3bfb80b6be71ab7