### PR TITLE
Fix Dockerfile to use stable Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.23-alpine
+FROM golang:1.23
 
 WORKDIR /app
 COPY . .
-RUN go build -o server ./cmd/server
+RUN go build -o out ./cmd/server
 
 EXPOSE 8080
-CMD ["./server"]
+CMD ["./out"]


### PR DESCRIPTION
## Summary
- ensure Dockerfile uses official Go 1.23 image
- build server binary as `out`

## Testing
- `go build ./cmd/server` *(fails: Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_6844c2abf6348328b3e04a64f45133ed