### PR TITLE
Fix deployment failure by pinning stable nixpkgs

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,6 @@
 [phases.setup]
 nixPkgs = ["go_1_23"]
+nixpkgsArchive = "5d562c02e45b0cd41b6edfc8458d4f3e4c15651a"
 
 [phases.build]
 cmds = ["go build -o out ./cmd/server"]


### PR DESCRIPTION
## Summary
- pin `nixpkgsArchive` so that `go_1_23` resolves to the stable Go release

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844c56480bc8328a3a1451c6b5e523a