### PR TITLE
Fix deployment by removing nixpacks

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,9 +1,0 @@
-[phases.setup]
-nixPkgs = ["go_1_23"]
-nixpkgsArchive = "5d562c02e45b0cd41b6edfc8458d4f3e4c15651a"
-
-[phases.build]
-cmds = ["go build -o out ./cmd/server"]
-
-[start]
-cmd = "./out"


### PR DESCRIPTION
## Summary
- remove nixpacks configuration to avoid failing Nix builds

## Testing
- `go build ./cmd/server` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844c8d90d9c83288affb47a111041f8