### PR TITLE
Fix docker-compose configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,14 @@ services:
   qrkit:
     build: .
     ports:
-      - "8080:8080"
+      - "8081:8080"
     volumes:
       - ./static:/app/static
       - ./templates:/app/templates
     environment:
       - LIVEKIT_API_KEY=mykey
       - LIVEKIT_API_SECRET=mysecret
-      - LIVEKIT_HOST=localhost:7880
+      - LIVEKIT_HOST=livekit:7880
     depends_on:
       - livekit
 
@@ -25,4 +25,4 @@ services:
     volumes:
       - ./livekit-local.yaml:/livekit.yaml
     environment:
-      - "LIVEKIT_KEYS=mykey: mysecret"
+      - "LIVEKIT_KEYS=mykey:mysecret"


### PR DESCRIPTION
## Summary
- update docker-compose service to match README snippet and fix env var

## Testing
- `go build ./cmd/server` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68456c728c90832889d516dd33279590