### PR TITLE
Add db and redis services

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ go build -o server ./cmd/server
 ### Opção 3: Docker Compose
 
 ```bash
-# Inicie todos os serviços com Docker
+# Inicie qrkit, livekit, PostgreSQL e Redis
 docker-compose up -d
 
 # Verifique os logs
 docker-compose logs -f
 ```
+
+Com todos os containers em execução, o QRKit acessará o banco PostgreSQL e o Redis utilizando as variáveis `DATABASE_URL` e `REDIS_URL` definidas no `docker-compose`.
 
 ## 🌐 Acessos
 
@@ -139,6 +141,8 @@ O sistema inclui várias ferramentas de teste:
 
 - **qrkit**: Aplicação Go principal (porta 8080)
 - **livekit**: Servidor LiveKit (porta 7880)
+- **db**: PostgreSQL com volume persistente
+- **redis**: Cache/filas (porta 6379)
 
 ### Configuração:
 
@@ -150,6 +154,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
+      - db
+      - redis
       - livekit
 
   livekit:
@@ -158,6 +164,19 @@ services:
       - "7880:7880"
       - "7881:7881/udp"
       - "50000-50100:50000-50100/udp"
+
+  db:
+    image: postgres:15
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+volumes:
+  db-data:
 ```
 
 ## 🔐 Configuração
@@ -167,6 +186,10 @@ services:
 - `LIVEKIT_API_KEY`: Chave da API LiveKit (padrão: "mykey")
 - `LIVEKIT_API_SECRET`: Secret da API LiveKit (padrão: "mysecret")
 - `LIVEKIT_HOST`: Host do servidor LiveKit (padrão: "localhost:7880")
+- `DATABASE_URL`: String de conexão PostgreSQL (padrão: `postgres://qrkit:qrkitpass@db:5432/qrkit?sslmode=disable`)
+- `REDIS_URL`: Endereço do Redis (padrão: `redis://redis:6379`)
+
+QRKit lê essas variáveis para conectar ao banco de dados e ao cache automaticamente quando os containers estão ativos.
 
 ### LiveKit Configuration:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,11 @@ services:
       - LIVEKIT_API_KEY=mykey
       - LIVEKIT_API_SECRET=mysecret
       - LIVEKIT_HOST=livekit:7880
+      - DATABASE_URL=postgres://qrkit:qrkitpass@db:5432/qrkit?sslmode=disable
+      - REDIS_URL=redis://redis:6379
     depends_on:
+      - db
+      - redis
       - livekit
 
   livekit:
@@ -26,3 +30,22 @@ services:
       - ./livekit-local.yaml:/livekit.yaml
     environment:
       - "LIVEKIT_KEYS=mykey:mysecret"
+
+  db:
+    image: postgres:15
+    restart: always
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: qrkit
+      POSTGRES_PASSWORD: qrkitpass
+      POSTGRES_DB: qrkit
+
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add PostgreSQL and Redis services to docker-compose
- set dependencies for qrkit on db, redis, and livekit
- document DATABASE_URL and REDIS_URL variables
- update README Docker instructions

## Testing
- `go mod tidy` *(fails: forbidden)*
- `go build ./...` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845884258488328a1fa8afc3ab76d2b