### PR TITLE
Fix token endpoint references and queue parsing

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -241,6 +241,7 @@ func joinQueue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		defer r.Body.Close()
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/livekit/protocol/auth"
@@ -233,17 +235,33 @@ func joinQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessionID := r.FormValue("sessionId")
-	if sessionID == "" {
+	var payload struct {
+		SessionID string `json:"sessionId"`
+		RoomName  string `json:"roomName"`
+	}
+
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if payload.SessionID == "" {
+		payload.SessionID = r.FormValue("sessionId")
+	}
+	if payload.RoomName == "" {
+		payload.RoomName = r.FormValue("roomName")
+	}
+	if payload.SessionID == "" {
 		http.Error(w, "sessionId required", http.StatusBadRequest)
 		return
 	}
-	roomName := r.FormValue("roomName")
-	if roomName == "" {
-		roomName = sessions[sessionID]
+	if payload.RoomName == "" {
+		payload.RoomName = sessions[payload.SessionID]
 	}
 
-	qi := QueueItem{SessionID: sessionID, RoomName: roomName, Timestamp: time.Now()}
+	qi := QueueItem{SessionID: payload.SessionID, RoomName: payload.RoomName, Timestamp: time.Now()}
 	employeeQueue = append(employeeQueue, qi)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/static/debug-final.html
+++ b/static/debug-final.html
@@ -187,7 +187,7 @@
 
                 // Passo 4: Solicitar token
                 addLog('Passo 3: Solicitando token JWT...');
-                const tokenResponse = await fetch('/token', {
+                const tokenResponse = await fetch('/api/token', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({

--- a/static/debug-livekit.html
+++ b/static/debug-livekit.html
@@ -172,7 +172,7 @@
       log('Iniciando teste de conectividade com backend...');
       
       try {
-        const response = await fetch('/token?room=test&identity=debug-user');
+        const response = await fetch('/api/token?room=test&identity=debug-user');
         
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/static/debug-webrtc.html
+++ b/static/debug-webrtc.html
@@ -138,7 +138,7 @@
                 log('🔄 Testando geração de token...', 'info');
                 updateStatus('token-section', 'Gerando token...', 'warning');
                 
-                const response = await fetch('/token?room=debug-room&identity=debug-user');
+                const response = await fetch('/api/token?room=debug-room&identity=debug-user');
                 const data = await response.json();
                 
                 if (data.token) {

--- a/static/quick-test.html
+++ b/static/quick-test.html
@@ -130,7 +130,7 @@
 
                 // 3. Obter token
                 log('🔄 Obtendo token JWT...');
-                const response = await fetch('/token?room=quick-test&identity=test-user');
+                const response = await fetch('/api/token?room=quick-test&identity=test-user');
                 const data = await response.json();
                 if (!data.token) {
                     throw new Error('Falha na geração do token');

--- a/static/test-complete.html
+++ b/static/test-complete.html
@@ -218,7 +218,7 @@
     async function testTokenGeneration() {
       log('Testando geração de token...');
       try {
-        const response = await fetch(`/token?room=test-room&identity=test-user`);
+        const response = await fetch(`/api/token?room=test-room&identity=test-user`);
         if (response.ok) {
           const data = await response.json();
           if (data.token) {

--- a/static/test-livekit.html
+++ b/static/test-livekit.html
@@ -114,7 +114,7 @@
         
         // Teste 2: Verificar se consegue pegar token
         log('Teste 2: Solicitando token...');
-        const resp = await fetch('/token?room=test&identity=test-user');
+        const resp = await fetch('/api/token?room=test&identity=test-user');
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         log('✅ Token recebido');

--- a/templates/video.html
+++ b/templates/video.html
@@ -110,7 +110,7 @@
       async function fetchToken(identity) {
       updateStatus('Solicitando token...');
       addDebugInfo(`Solicitando token para identidade: ${identity}, sala: ${roomName}`);
-      const resp = await fetch(`/token?room=${roomName}&identity=${identity}`);
+      const resp = await fetch(`/api/token?room=${roomName}&identity=${identity}`);
       if (!resp.ok) {
         addDebugInfo(`Erro HTTP: ${resp.status} ${resp.statusText}`);
         throw new Error('Erro ao obter token do servidor');


### PR DESCRIPTION
## Summary
- fix path references to `/api/token` across templates and static test files
- allow JSON payloads for `/api/join-queue`

## Testing
- `go vet ./...` *(fails: Get github.com/livekit/protocol... Forbidden)*
- `go build ./...` *(fails: Get github.com/livekit/protocol... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ba4f93dc832886610ab8aa9ec83d